### PR TITLE
Update to latest z88dk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ basloader.tap: loader.bas
 	bas2tap -q -a -s$(TAP_NAME) $< $@
 
 loader.tap: loader.asm basloader.tap loading_screen.tap main.tap
-	echo "DEFC LOADING_SIZE = $(shell stat -c "%s" loading_ucl.bin)" > loader.opt
-	echo "DEFC APP_SIZE = $(shell stat -c "%s" main.bin)" >> loader.opt
+	echo "DEFC LOADING_SIZE = $(shell stat -f "%z" loading_ucl.bin)" > loader.opt
+	echo "DEFC APP_SIZE = $(shell stat -f "%z" main.bin)" >> loader.opt
 	echo "DEFC LOAD_ADDR = $(LOAD_ADDR)" >> loader.opt
-	z80asm -b -ns -Mbin -ilib/ucl -oloader.bin $<
+	z80asm -b -oloader.bin $< lib/ucl.asm 
 	bin2tap -a 64856 -o loading.tap loader.bin
 	cat basloader.tap loading.tap loading_screen.tap > $@
 
 main.bin: main.c int.h misc.h lib/ucl.h sprites.h beeper.h numbers.h font.h $(GENERATED)
-	zcc $(CFLAGS) $< -o u$@ -lsp1 -lmalloc -llib/ucl -zorg=$(LOAD_ADDR)
+	zcc $(CFLAGS) $< -o u$@ -lsp1 -llib/ucl -zorg=$(LOAD_ADDR) -pragma-include:zpragma.inc -unsigned
 	ucl < umain.bin > main.bin
 
 loading_screen.tap: loading.png
@@ -104,22 +104,22 @@ sentinel2.h: sentinel2.png
 	png2sprite.py -i sentinel2 sentinel2.png > sentinel2.h
 
 prdr.h: prdr.asm
-	z80asm -b -ns -Mbin -oprdr.bin $<
+	z80asm -b -oprdr.bin $<
 	ucl < prdr.bin > prdr_ucl.bin
 	bin2h.py prdr_ucl.bin prdr > prdr.h
 
 song1.h: song1.asm
-	z80asm -b -ns -Mbin -osong1.bin $<
+	z80asm -b  -osong1.bin $<
 	ucl < song1.bin > song1_ucl.bin
 	bin2h.py song1_ucl.bin song1 > song1.h
 
 song2.h: song2.asm
-	z80asm -b -ns -Mbin -osong2.bin $<
+	z80asm -b   -osong2.bin $<
 	ucl < song2.bin > song2_ucl.bin
 	bin2h.py song2_ucl.bin song2 > song2.h
 
 song3.h: song3.asm
-	z80asm -b -ns -Mbin -osong3.bin $<
+	z80asm -b  -osong3.bin $<
 	ucl < song3.bin > song3_ucl.bin
 	bin2h.py song3_ucl.bin song3 > song3.h
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all:
 	make -C tools
 	make -C lib
 	make $(TAP_NAME).tap
-	chksize $(MAX_MEM) umain.bin
+	tools/chksize $(MAX_MEM) umain.bin
 
 $(TAP_NAME).tap: loader.tap main.tap
 	cat loader.tap main.tap > $@
@@ -37,7 +37,7 @@ loader.tap: loader.asm basloader.tap loading_screen.tap main.tap
 	cat basloader.tap loading.tap loading_screen.tap > $@
 
 main.bin: main.c int.h misc.h lib/ucl.h sprites.h beeper.h numbers.h font.h $(GENERATED)
-	zcc $(CFLAGS) $< -o u$@ -lsp1 -llib/ucl -zorg=$(LOAD_ADDR) -pragma-include:zpragma.inc -unsigned
+	zcc $(CFLAGS) $< -o u$@ -lsp1 -llib/ucl -zorg=$(LOAD_ADDR) -pragma-include:zpragma.inc 
 	ucl < umain.bin > main.bin
 
 loading_screen.tap: loading.png

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ compile the game.
 
 You will need:
 
-- A POSIX environment (Linux is perfect)
-- GCC, GNU Make, Python 2
-- Z88DK v1.9 (other versions may or may not work)
+- A POSIX environment (tested on Macos)
+- GCC, GNU Make, Python 3
+- z88dk nightly dated 20210406 or later
 - sp1.lib from Z88DK
 
 Then cross your fingers and run `make`.
@@ -21,8 +21,8 @@ It should end with:
 ```
 ***
     Max: 26936 bytes
-Current: 26875 bytes (umain.bin)
-   Left: 61 bytes
+Current: 26431 bytes (umain.bin)
+   Left: 505 bytes
 ***
 ```
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,7 +6,7 @@ export ZCCCFG:=$(abspath ../../z88dk/lib/config)/
 
 ucl.lib: ucl.asm
 	echo ucl > ucl.lst
-	z80asm -d -ns -nm -Mo -xucl @ucl.lst
+	z80asm -d -xucl @ucl.lst
 	rm ucl.lst
 
 clean:

--- a/loader.asm
+++ b/loader.asm
@@ -1,7 +1,7 @@
 	; this forces a 512 bytes limit for the loader!
 	ORG 64856
 
-LIB ucl_uncompress
+EXTERN ucl_uncompress
 
 INCLUDE "loader.opt"
 

--- a/main.c
+++ b/main.c
@@ -30,6 +30,7 @@
 #define WFRAMES 3
 
 // generated includes that are OK with contended memory
+// Place all const data into contended memory
 #pragma constseg CONTENDED
 #include "dr_text.h"
 #include "prdr.h"
@@ -44,7 +45,6 @@
 #include "numbersx2.h"
 #include "numbers.h"
 #include "font.h"
-#pragma constseg rodata_compiler
 
 
 // convenient global variables (for speed)
@@ -2911,6 +2911,7 @@ main()
 
     setup_int();
 
+    zx_border(INK_BLACK);
     // sp1.lib
     sp1_Initialize(SP1_IFLAG_MAKE_ROTTBL | SP1_IFLAG_OVERWRITE_TILES | SP1_IFLAG_OVERWRITE_DFILE, INK_BLACK | PAPER_BLACK, ' ');
 

--- a/main.c
+++ b/main.c
@@ -128,7 +128,7 @@ const struct sp1_Rect gr = { 0, 0, 32, 20 };
 
 // keys
 uint keys[5] = { 'o', 'p', 'q', ' ', 'h' };
-int (*joyfunc)() __z88dk_fastcall;
+uint (*joyfunc)(struct in_UDK *) __z88dk_fastcall;
 struct in_UDK joy_k;
 
 // FIXME: set an initial hiscore!
@@ -146,7 +146,7 @@ const struct sp1_Rect rdk = { 8, 2, 30, 12 };
     void
 run_redefine_keys()
 {
-    sp1_ClearRectInv((struct sp1_Rect *)&rdk, INK_BLACK | PAPER_BLACK, 32, SP1_RFLAG_TILE | SP1_RFLAG_COLOUR);
+    sp1_ClearRectInv(&rdk, INK_BLACK | PAPER_BLACK, 32, SP1_RFLAG_TILE | SP1_RFLAG_COLOUR);
 
     print(10, 9, INK_WHITE|BRIGHT, "REDEFINE KEYS");
     print(9, 13, INK_WHITE|BRIGHT, "PRESS KEY\x3a");

--- a/misc.h
+++ b/misc.h
@@ -66,7 +66,7 @@ pad_numbers(uchar *s, uint limit, uint number)
 }
 
 void __CALLEE__
-setup_tiles(uchar *src, uchar base, uchar len)
+setup_tiles(uchar *src, uchar base, uchar len) __naked
 {
 	/*
 	for (i = 0; i < len; ++i, src += 8)
@@ -100,11 +100,12 @@ setup_tiles(uchar *src, uchar base, uchar len)
 	inc c
 
 	djnz setup_tiles_loop
+	ret
 #endasm
 }
 
 void __CALLEE__
-print(uchar x, uchar y, uchar attr, char *str)
+print(uchar x, uchar y, uchar attr, char *str) __naked
 {
 	/*
 	while(*str)
@@ -155,6 +156,7 @@ print(uchar x, uchar y, uchar attr, char *str)
 	pop af
 	pop af
 	push hl
+	ret
 #endasm
 }
 

--- a/prdr.asm
+++ b/prdr.asm
@@ -43,7 +43,7 @@
 	xor a
 	in a,($fe)
 	cpl
-	and #31
+	and $31
 	jp nz,stopPlayer
 
 	ld c,(hl)

--- a/prdr.asm
+++ b/prdr.asm
@@ -43,7 +43,7 @@
 	xor a
 	in a,($fe)
 	cpl
-	and $31
+	and 31
 	jp nz,stopPlayer
 
 	ld c,(hl)

--- a/tools/bin2h.py
+++ b/tools/bin2h.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from argparse import ArgumentParser
 

--- a/tools/chksize
+++ b/tools/chksize
@@ -7,7 +7,7 @@ if [ $# -ne 2 ]; then
 	exit 1
 fi
 
-CURRENT=`stat -c %s $2`
+CURRENT=`stat -f %z $2`
 LEFT=$(($1 - $CURRENT))
 
 cat <<ENDL

--- a/tools/map.py
+++ b/tools/map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 __version__ = "1.0"
 
@@ -310,7 +310,7 @@ def main():
         for block in out:
             p = subprocess.Popen(["ucl",], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
             output, err = p.communicate(bytearray(block))
-            compressed.append([ord(b) for b in output])
+            compressed.append([ord(chr(b)) for b in output])
         out = compressed
 
     print("/* imported from %s */" % args.map_json)

--- a/tools/png2c.py
+++ b/tools/png2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 png2c.py
 Copyright (C) 2014-2016 by Juan J. Martinez - usebox.net
@@ -243,7 +243,7 @@ def main():
     if args.ucl:
         p = subprocess.Popen(["ucl",], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         output, err = p.communicate(bytearray(out))
-        out = [ord(b) for b in output]
+        out = [ord(chr(b)) for b in output]
 
     data_out = ""
     for part in range(0, len(out), 8):

--- a/tools/png2scr.py
+++ b/tools/png2scr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 png2scr.py
 Copyright (C) 2014-2016 by Juan J. Martinez - usebox.net

--- a/tools/png2sprite.py
+++ b/tools/png2sprite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 png2sprite.py
 Copyright (C) 2014 by Juan J. Martinez - usebox.net
@@ -74,7 +74,7 @@ def main():
 
     tiles = []
     # this is wrong, but assuming nxn sprites works
-    for j in range(h / 8):
+    for j in range(int(h / 8)):
         if not args.nomask:
             tiles.extend([255, 0, 255, 0, 255, 0, 255, 0])
 

--- a/zpragma.inc
+++ b/zpragma.inc
@@ -1,0 +1,19 @@
+
+// Console not used, disable it
+#pragma export fputc_cons = 0
+
+// Not a 128k game, so disable the bank loader
+#pragma define CRT_DISABLELOADER = 1
+
+#pragma output REGISTER_SP = 0xd000
+
+#pragma define CRT_ORG_CODE = 24100
+
+// We're not exiting, so we don't need an atexit stack
+#pragma define CLIB_EXIT_STACK_SIZE = 0
+
+// Stdio isn't used, disable it
+#pragma define CRT_ENABLE_STDIO = 0
+
+// Ensure that we don't map the border colour
+#pragma define CONIO_NATIVE_COLOUR = 1


### PR DESCRIPTION
I genuinely don't know if you'll be interested in this, so feel free to reject.

z88dk 1.9 is ancient, and took a lot of bodging for me to get it built on 64 bit hardware. I couldn't then create a working binary, so I'm obviously missing a few more tweaks. However, I'm not overly interested in that sort of software archaeology, so....

Updating the codebase to run with the latest z88dk was pretty simple. These are minimal changes which don't change the code beyond what is necessary to make things work.

- Adding `__naked` to the `__z88dk_callee` functions - you'll know that decorator from sdcc. I did the `__z88dk_fastcall` ones for completeness as well.
- Adding zpragma.inc for tuning options: mainly turning off unwanted features
- Marking the joystick function pointer as `__z88dk_fastcall`
- Fiddling around with sections to push const data into contended memory
- Case sensitivity for a couple of labels
- Sorting out the z80asm options

Additional:

- Update to python3
- Change the stat command which has a different set of arguments on macOS 

There's rather a lot of warnings concerning casting away constness which I've not tackled.

As far as I can tell it plays correctly but I've not gone beyond the first few screens.

